### PR TITLE
[hard]Scrapper utility: recurring non blocking timeout for get_page()

### DIFF
--- a/Scrapper-Service/requirements.txt
+++ b/Scrapper-Service/requirements.txt
@@ -12,3 +12,4 @@ traceback2==1.4.0
 unittest2==1.1.0
 urllib3==1.25.8
 dill==0.3.1.1
+backoff==1.10.0


### PR DESCRIPTION
# Summary
**Exponential backoff algorithm** used to handle network issues for ```get_page()``` function. This was done using Python ```backoff``` library. ```max_time``` parameter used to add timeout.

Fixes #29

# Tests
```sh
(venv) HP:Scrapper-Service shardulaeer$ python -m unittest test -v
test_invalid_data (test.conference_test.ConferenceTestCase) ... Object initialisation failed successfully  deadline 
is not datetime , deadline value: anything
ok
test_valid_data (test.conference_test.ConferenceTestCase) ... ok
test_invalid_data (test.metadata_test.MetadataTestCase) ... Object initialisation failed successfully  deadline is n
ot datetime , deadline value: anything
ok
test_valid_data (test.metadata_test.MetadataTestCase) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.004s

OK
```

![image](https://user-images.githubusercontent.com/49580849/77657870-e58c1b80-6f9b-11ea-9500-17df534ab3f1.png)

# References
1. https://github.com/litl/backoff
2. https://en.wikipedia.org/wiki/Exponential_backoff