### PR TITLE
Streams for each of CRUD operations added

### DIFF
--- a/Notifier-service/src/app.ts
+++ b/Notifier-service/src/app.ts
@@ -34,7 +34,7 @@ export class App {
             process.exit(0);
             
         });
-        // this.listeners = container.getAll<Listener>(Listener)
+        this.listeners = container.getListeners()
     }
 
     init():void{

--- a/Notifier-service/src/app.ts
+++ b/Notifier-service/src/app.ts
@@ -1,10 +1,11 @@
 import express from 'express';
-import { Application , Request , Response } from 'express';
+import { Application} from 'express';
 import { Server } from 'http';
 import { Logger } from './utility/log';
 import { Route } from './interfaces/route';
 import { Listener } from './interfaces/listener';
 import { AppContainer } from './inversify.config';
+import { Database } from './interfaces/database';
 
 
 
@@ -13,6 +14,7 @@ export class App {
     private logger = new Logger(this.constructor.name).getLogger();
     private app:Application;
     private server:Server|undefined;
+    public databaseobj:Database;
     
     // Routes for registering toe express application
     private routes:Route[] =[];
@@ -22,8 +24,17 @@ export class App {
 
     constructor(private container:AppContainer){
         this.app = express();
-        this.routes = container.getRoutes()
-        this.listeners = container.getListeners()
+        this.routes = container.getRoutes();
+        this.databaseobj=container.getDatabase();
+
+        // EventHandler to trigger Interrupt signal and close the database
+        process.on('SIGINT', async() => {
+            this.logger.info("Closing the Database!");
+            await this.databaseobj.close();
+            process.exit(0);
+            
+        });
+        // this.listeners = container.getAll<Listener>(Listener)
     }
 
     init():void{

--- a/Notifier-service/src/app.ts
+++ b/Notifier-service/src/app.ts
@@ -35,6 +35,7 @@ export class App {
             
         });
         this.listeners = container.getListeners()
+        // this.listeners = container.getAll<Listener>(Listener)
     }
 
     init():void{

--- a/Notifier-service/src/app.ts
+++ b/Notifier-service/src/app.ts
@@ -23,7 +23,7 @@ export class App {
     constructor(private container:AppContainer){
         this.app = express();
         this.routes = container.getRoutes()
-        // this.listeners = container.getAll<Listener>(Listener)
+        this.listeners = container.getListeners()
     }
 
     init():void{

--- a/Notifier-service/src/interfaces/services/streams/conferenceStream.ts
+++ b/Notifier-service/src/interfaces/services/streams/conferenceStream.ts
@@ -16,5 +16,9 @@ import { injectable } from "inversify";
 @injectable()
 export abstract class ConferenceStream implements Stream{
     constructor(private conferenceModel:ConferenceModel){}
-    abstract getStream():Observable<any>
+    abstract getStream():Observable<any>;
+    abstract getInsertStream():Observable<any>;
+    abstract getUpdateStream():Observable<any>;
+    abstract getDeleteStream():Observable<any>;
+    abstract getReplaceStream():Observable<any>;
 }

--- a/Notifier-service/src/interfaces/stream.ts
+++ b/Notifier-service/src/interfaces/stream.ts
@@ -10,5 +10,9 @@ import { Observable } from "rxjs";
  * @interface Stream
  */
 export interface Stream{
-    getStream():Observable<any>
+    getStream():Observable<any>;
+    getInsertStream():Observable<any>;
+    getUpdateStream():Observable<any>;
+    getDeleteStream():Observable<any>;
+    getReplaceStream():Observable<any>;
 }

--- a/Notifier-service/src/interfaces/stream.ts
+++ b/Notifier-service/src/interfaces/stream.ts
@@ -11,8 +11,4 @@ import { Observable } from "rxjs";
  */
 export interface Stream{
     getStream():Observable<any>;
-    getInsertStream():Observable<any>;
-    getUpdateStream():Observable<any>;
-    getDeleteStream():Observable<any>;
-    getReplaceStream():Observable<any>;
 }

--- a/Notifier-service/src/services/streams/conferenceStream.ts
+++ b/Notifier-service/src/services/streams/conferenceStream.ts
@@ -44,66 +44,66 @@ export class ConferenceStreamMongo extends ConferenceStream {
             .pipe(
                 share()
             )
-        let isInsert = this.getStream().pipe(filter(data => {
+        this.insertstreamObs$ = this.getStream().pipe(filter(data => {
             return data.operationType == 'insert'
         }))
-        let isUpdate = this.getStream().pipe(filter(data => {
+        this.updatestreamObs$ = this.getStream().pipe(filter(data => {
             return data.operationType == 'update'
         }))
-        let isDelete = this.getStream().pipe(filter(data => {
+        this.deletestreamObs$ = this.getStream().pipe(filter(data => {
             return data.operationType == 'delete'
         }))
-        let isReplace = this.getStream().pipe(filter(data => {
+        this.replacestreamObs$ = this.getStream().pipe(filter(data => {
             return data.operationType == 'replace' 
         }))
             
-        this.insertstreamObs$ = Observable.create((observer: Observer<any>) => {
-            changeStream.then(stream => {
-                stream.on("insert", (data:Object) => {
-                    observer.next(data)
-                })
-            }).catch(error => {
-                this.logger.error(`insert stream failed:${error}`)
-                observer.error(error)
-                observer.complete()
-            })
-        })
+        // this.insertstreamObs$ = Observable.create((observer: Observer<any>) => {
+        //     changeStream.then(stream => {
+        //         stream.on("insert", (data:Object) => {
+        //             observer.next(data)
+        //         })
+        //     }).catch(error => {
+        //         this.logger.error(`insert stream failed:${error}`)
+        //         observer.error(error)
+        //         observer.complete()
+        //     })
+        // })
 
-        this.updatestreamObs$ = Observable.create((observer: Observer<any>) => {
-            changeStream.then(stream => {
-                stream.on("update", (data:Object) => {
-                    observer.next(data)
-                })
-            }).catch(error => {
-                this.logger.error(`update stream failed:${error}`)
-                observer.error(error)
-                observer.complete()
-            })
-        })
+        // this.updatestreamObs$ = Observable.create((observer: Observer<any>) => {
+        //     changeStream.then(stream => {
+        //         stream.on("update", (data:Object) => {
+        //             observer.next(data)
+        //         })
+        //     }).catch(error => {
+        //         this.logger.error(`update stream failed:${error}`)
+        //         observer.error(error)
+        //         observer.complete()
+        //     })
+        // })
 
-        this.deletestreamObs$ = Observable.create((observer: Observer<any>) => {
-            changeStream.then(stream => {
-                stream.on("delete", (data:Object) => {
-                    observer.next(data)
-                })
-            }).catch(error => {
-                this.logger.error(`delete stream failed:${error}`)
-                observer.error(error)
-                observer.complete()
-            })
-        })
+        // this.deletestreamObs$ = Observable.create((observer: Observer<any>) => {
+        //     changeStream.then(stream => {
+        //         stream.on("delete", (data:Object) => {
+        //             observer.next(data)
+        //         })
+        //     }).catch(error => {
+        //         this.logger.error(`delete stream failed:${error}`)
+        //         observer.error(error)
+        //         observer.complete()
+        //     })
+        // })
 
-        this.replacestreamObs$ = Observable.create((observer: Observer<any>) => {
-            changeStream.then(stream => {
-                stream.on("replace", (data:Object) => {
-                    observer.next(data)
-                })
-            }).catch(error => {
-                this.logger.error(`replace stream failed:${error}`)
-                observer.error(error)
-                observer.complete()
-            })
-        })
+        // this.replacestreamObs$ = Observable.create((observer: Observer<any>) => {
+        //     changeStream.then(stream => {
+        //         stream.on("replace", (data:Object) => {
+        //             observer.next(data)
+        //         })
+        //     }).catch(error => {
+        //         this.logger.error(`replace stream failed:${error}`)
+        //         observer.error(error)
+        //         observer.complete()
+        //     })
+        // })
     }
 
     public getStream(): Observable<any> {

--- a/Notifier-service/src/services/streams/conferenceStream.ts
+++ b/Notifier-service/src/services/streams/conferenceStream.ts
@@ -56,54 +56,6 @@ export class ConferenceStreamMongo extends ConferenceStream {
         this.replacestreamObs$ = this.getStream().pipe(filter(data => {
             return data.operationType == 'replace' 
         }))
-            
-        // this.insertstreamObs$ = Observable.create((observer: Observer<any>) => {
-        //     changeStream.then(stream => {
-        //         stream.on("insert", (data:Object) => {
-        //             observer.next(data)
-        //         })
-        //     }).catch(error => {
-        //         this.logger.error(`insert stream failed:${error}`)
-        //         observer.error(error)
-        //         observer.complete()
-        //     })
-        // })
-
-        // this.updatestreamObs$ = Observable.create((observer: Observer<any>) => {
-        //     changeStream.then(stream => {
-        //         stream.on("update", (data:Object) => {
-        //             observer.next(data)
-        //         })
-        //     }).catch(error => {
-        //         this.logger.error(`update stream failed:${error}`)
-        //         observer.error(error)
-        //         observer.complete()
-        //     })
-        // })
-
-        // this.deletestreamObs$ = Observable.create((observer: Observer<any>) => {
-        //     changeStream.then(stream => {
-        //         stream.on("delete", (data:Object) => {
-        //             observer.next(data)
-        //         })
-        //     }).catch(error => {
-        //         this.logger.error(`delete stream failed:${error}`)
-        //         observer.error(error)
-        //         observer.complete()
-        //     })
-        // })
-
-        // this.replacestreamObs$ = Observable.create((observer: Observer<any>) => {
-        //     changeStream.then(stream => {
-        //         stream.on("replace", (data:Object) => {
-        //             observer.next(data)
-        //         })
-        //     }).catch(error => {
-        //         this.logger.error(`replace stream failed:${error}`)
-        //         observer.error(error)
-        //         observer.complete()
-        //     })
-        // })
     }
 
     public getStream(): Observable<any> {

--- a/Notifier-service/src/services/streams/conferenceStream.ts
+++ b/Notifier-service/src/services/streams/conferenceStream.ts
@@ -4,7 +4,7 @@ import { ConferenceDocument } from "../../schemas/conferences";
 import { injectable } from "inversify";
 import { Logger } from "../../utility/log";
 import { Observable, Observer } from 'rxjs'
-import { share } from 'rxjs/operators'
+import { share, filter } from 'rxjs/operators'
 
 import { ConferenceStream } from "../../interfaces/services/streams/conferenceStream";
 
@@ -14,6 +14,10 @@ export class ConferenceStreamMongo extends ConferenceStream {
 
     private logger = new Logger(this.constructor.name).getLogger()
     private streamObs$: Observable<any>
+    private insertstreamObs$: Observable<any>;
+    private updatestreamObs$: Observable<any>;
+    private deletestreamObs$: Observable<any>;
+    private replacestreamObs$: Observable<any>;
     constructor(conferenceModel: ConferenceModel) {
         super(conferenceModel)
         this.logger.info("Conference Stream started")
@@ -39,16 +43,72 @@ export class ConferenceStreamMongo extends ConferenceStream {
             })
         })
             .pipe(
-                share()
+                filter()
             )
+        this.insertstreamObs$ = Observable.create((observer: Observer<any>) => {
+            changeStream.then(stream => {
+                stream.on("insert", (data:Object) => {
+                    observer.next(data)
+                })
+            }).catch(error => {
+                this.logger.error(`insert stream failed:${error}`)
+                observer.error(error)
+                observer.complete()
+            })
+        })
 
+        this.updatestreamObs$ = Observable.create((observer: Observer<any>) => {
+            changeStream.then(stream => {
+                stream.on("update", (data:Object) => {
+                    observer.next(data)
+                })
+            }).catch(error => {
+                this.logger.error(`update stream failed:${error}`)
+                observer.error(error)
+                observer.complete()
+            })
+        })
 
+        this.deletestreamObs$ = Observable.create((observer: Observer<any>) => {
+            changeStream.then(stream => {
+                stream.on("delete", (data:Object) => {
+                    observer.next(data)
+                })
+            }).catch(error => {
+                this.logger.error(`delete stream failed:${error}`)
+                observer.error(error)
+                observer.complete()
+            })
+        })
+
+        this.replacestreamObs$ = Observable.create((observer: Observer<any>) => {
+            changeStream.then(stream => {
+                stream.on("replace", (data:Object) => {
+                    observer.next(data)
+                })
+            }).catch(error => {
+                this.logger.error(`replace stream failed:${error}`)
+                observer.error(error)
+                observer.complete()
+            })
+        })
     }
 
     public getStream(): Observable<any> {
         return this.streamObs$;
     }
-
+    public getInsertStream():Observable<any> {
+        return this.insertstreamObs$;
+    }
+    public getUpdateStream():Observable<any> {
+        return this.updatestreamObs$;
+    }
+    public getDeleteStream():Observable<any> {
+        return this.deletestreamObs$;
+    }
+    public getReplaceStream():Observable<any> {
+        return this.replacestreamObs$;
+    }
 
 
 } 

--- a/Notifier-service/src/services/streams/conferenceStream.ts
+++ b/Notifier-service/src/services/streams/conferenceStream.ts
@@ -3,8 +3,8 @@ import { ConferenceModel } from "../../interfaces/models/conference";
 import { ConferenceDocument } from "../../schemas/conferences";
 import { injectable } from "inversify";
 import { Logger } from "../../utility/log";
-import { Observable, Observer } from 'rxjs'
-import { share, filter } from 'rxjs/operators'
+import { Observable, Observer, observable } from 'rxjs'
+import { share, filter, map } from 'rxjs/operators'
 
 import { ConferenceStream } from "../../interfaces/services/streams/conferenceStream";
 
@@ -43,8 +43,7 @@ export class ConferenceStreamMongo extends ConferenceStream {
             })
         })
             .pipe(
-                share(),
-                filter(())
+                share()
             )
         this.insertstreamObs$ = Observable.create((observer: Observer<any>) => {
             changeStream.then(stream => {

--- a/Notifier-service/src/services/streams/conferenceStream.ts
+++ b/Notifier-service/src/services/streams/conferenceStream.ts
@@ -43,7 +43,8 @@ export class ConferenceStreamMongo extends ConferenceStream {
             })
         })
             .pipe(
-                filter()
+                share(),
+                filter(())
             )
         this.insertstreamObs$ = Observable.create((observer: Observer<any>) => {
             changeStream.then(stream => {
@@ -55,7 +56,9 @@ export class ConferenceStreamMongo extends ConferenceStream {
                 observer.error(error)
                 observer.complete()
             })
-        })
+        }).pipe(
+            share()
+        )
 
         this.updatestreamObs$ = Observable.create((observer: Observer<any>) => {
             changeStream.then(stream => {


### PR DESCRIPTION
#66 [Feature] add new stream filters like 'update'/'create'/'replace' etc for ConferenceStream 

Following functions added:

- getInsertStream()
- geUpdateStream()
- getDeleteStream()
- getReplaceStream()

Attached Insert stream testing after creating replica sets:
![Screenshot from 2020-04-09 21-27-17](https://user-images.githubusercontent.com/44888949/78915206-31b18280-7aa9-11ea-86ed-e4164ffc7569.png)
