### PR TITLE
Modified_array_push_to_store_unique_categories

### DIFF
--- a/Scrapper-Service/datamodels/conference.py
+++ b/Scrapper-Service/datamodels/conference.py
@@ -61,7 +61,7 @@ class Conference:
         
         if categories is not None:
             category_query = {"categories":{"$each":categories}}
-            self.query["$push"]=category_query
+            self.query["$addToSet"]=category_query
         
         
     def __generate_uuid(self):


### PR DESCRIPTION
#64 [Bug] categories in conference collection is getting duplicated over multiple runs

Before fix:
![Screenshot from 2020-04-13 20-23-28](https://user-images.githubusercontent.com/44888949/79130709-0be7ee80-7dc5-11ea-97db-f995854d7208.png)

After fix:
![Screenshot from 2020-04-13 20-23-33](https://user-images.githubusercontent.com/44888949/79130718-12766600-7dc5-11ea-8e75-a42eb98b8a52.png)
