### PR TITLE
modified get one function to provide conference info using Id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 **/**/__pycache__
+venv/

--- a/Notifier-service/src/controllers/conference.ts
+++ b/Notifier-service/src/controllers/conference.ts
@@ -20,10 +20,11 @@ export class ConferenceController extends Controller {
     getOne = async (request: Request, response: Response) => {
         let requester = request.ip;
         let category: string = request.params.category;
+        let _id: string = request.params.id;
         this.logger.info(this.success("getOne", requester))
         try {
 
-            let result = await this.conferenceService.getOne();
+            let result = await this.conferenceService.getOne(_id);
             response.json(this.successResponse(result));
         }
         catch (e) {

--- a/Notifier-service/src/interfaces/models/conference.ts
+++ b/Notifier-service/src/interfaces/models/conference.ts
@@ -15,7 +15,7 @@ import { Model } from '../model';
 @injectable()
 export abstract class ConferenceModel extends Model{
     protected abstract modelName:string;
-    abstract async getOne():Promise<ConferenceDocument | null>
+    abstract async getOne(query:any):Promise<ConferenceDocument | null>
     abstract async getConferences(offset:number , range:number):Promise<ConferenceDocument[] | null>
     abstract async getConferencesFromCategory(category:string , offset:number , range:number):Promise<ConferenceDocument[] | null>
     abstract async getCategories():Promise<Array<string> | null>

--- a/Notifier-service/src/interfaces/models/conference.ts
+++ b/Notifier-service/src/interfaces/models/conference.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { ConferenceDocument, mongoQueryType } from '../../schemas/conferences';
+import { ConferenceDocument } from '../../schemas/conferences';
 import { injectable } from 'inversify';
 import { Model } from '../model';
 
@@ -15,7 +15,7 @@ import { Model } from '../model';
 @injectable()
 export abstract class ConferenceModel extends Model{
     protected abstract modelName:string;
-    abstract async getOne(query:mongoQueryType):Promise<ConferenceDocument | null>
+    abstract async getOne(id: string):Promise<ConferenceDocument | null>
     abstract async getConferences(offset:number , range:number):Promise<ConferenceDocument[] | null>
     abstract async getConferencesFromCategory(category:string , offset:number , range:number):Promise<ConferenceDocument[] | null>
     abstract async getCategories():Promise<Array<string> | null>

--- a/Notifier-service/src/interfaces/models/conference.ts
+++ b/Notifier-service/src/interfaces/models/conference.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { ConferenceDocument } from '../../schemas/conferences';
+import { ConferenceDocument, mongoQueryType } from '../../schemas/conferences';
 import { injectable } from 'inversify';
 import { Model } from '../model';
 
@@ -15,7 +15,7 @@ import { Model } from '../model';
 @injectable()
 export abstract class ConferenceModel extends Model{
     protected abstract modelName:string;
-    abstract async getOne(query:any):Promise<ConferenceDocument | null>
+    abstract async getOne(query:mongoQueryType):Promise<ConferenceDocument | null>
     abstract async getConferences(offset:number , range:number):Promise<ConferenceDocument[] | null>
     abstract async getConferencesFromCategory(category:string , offset:number , range:number):Promise<ConferenceDocument[] | null>
     abstract async getCategories():Promise<Array<string> | null>

--- a/Notifier-service/src/interfaces/services/conference.ts
+++ b/Notifier-service/src/interfaces/services/conference.ts
@@ -10,5 +10,5 @@ export abstract class ConferenceService extends Service{
     abstract async getConferencesFromCategory(category:String , offset:Number , count:Number):Promise<Conference[]>
     abstract async getCategories():Promise<Array<string>>
 
-    abstract async getOne(queryKey: string, queryValue: string):Promise<Conference | null>
+    abstract async getOne(_id: string):Promise<Conference | null>
 }

--- a/Notifier-service/src/interfaces/services/conference.ts
+++ b/Notifier-service/src/interfaces/services/conference.ts
@@ -10,5 +10,5 @@ export abstract class ConferenceService extends Service{
     abstract async getConferencesFromCategory(category:String , offset:Number , count:Number):Promise<Conference[]>
     abstract async getCategories():Promise<Array<string>>
 
-    abstract async getOne():Promise<Conference | null>
+    abstract async getOne(queryKey: string, queryValue: string):Promise<Conference | null>
 }

--- a/Notifier-service/src/models/conference.ts
+++ b/Notifier-service/src/models/conference.ts
@@ -1,6 +1,6 @@
 import { Model } from 'mongoose';
 import { Connection } from 'mongoose';
-import { Conference, ConferenceDocument, ConferenceSchema } from '../schemas/conferences';
+import { Conference, ConferenceDocument, ConferenceSchema, mongoQueryType } from '../schemas/conferences';
 import { Database } from '../interfaces/database';
 import { ConferenceModel } from '../interfaces/models/conference';
 import { Logger } from '../utility/log';
@@ -50,7 +50,7 @@ export class ConferenceModelMongo extends ConferenceModel {
     }
 
 
-    async getOne(query:any = {}): Promise<ConferenceDocument | null> {
+    async getOne(query: mongoQueryType = {}): Promise<ConferenceDocument | null> {
         this.logger.debug("getOne invoked")
         let result = this.makeQuery((model) => {
             return new Promise<ConferenceDocument | null>((resolve, reject) => {

--- a/Notifier-service/src/models/conference.ts
+++ b/Notifier-service/src/models/conference.ts
@@ -1,6 +1,6 @@
 import { Model} from 'mongoose';
 import { Connection } from 'mongoose';
-import { Conference, ConferenceDocument, ConferenceSchema, mongoQueryType } from '../schemas/conferences';
+import { Conference, ConferenceDocument, ConferenceSchema } from '../schemas/conferences';
 import { Database } from '../interfaces/database';
 import { ConferenceModel } from '../interfaces/models/conference';
 import { Logger } from '../utility/log';
@@ -50,8 +50,9 @@ export class ConferenceModelMongo extends ConferenceModel {
     }
 
 
-    async getOne(query: mongoQueryType = {}): Promise<ConferenceDocument | null> {
+    async getOne(id: string): Promise<ConferenceDocument | null> {
         this.logger.debug("getOne invoked")
+        let query = {_id:id}
         let result = this.makeQuery((model) => {
             return new Promise<ConferenceDocument | null>((resolve, reject) => {
                 model.findOne(query, (err, res) => {

--- a/Notifier-service/src/models/conference.ts
+++ b/Notifier-service/src/models/conference.ts
@@ -50,11 +50,11 @@ export class ConferenceModelMongo extends ConferenceModel {
     }
 
 
-    async getOne(): Promise<ConferenceDocument | null> {
+    async getOne(query:any = {}): Promise<ConferenceDocument | null> {
         this.logger.debug("getOne invoked")
         let result = this.makeQuery((model) => {
             return new Promise<ConferenceDocument | null>((resolve, reject) => {
-                model.findOne({}, (err, res) => {
+                model.findOne(query, (err, res) => {
                     if (!err) {
                         resolve(res);
                     }

--- a/Notifier-service/src/models/conference.ts
+++ b/Notifier-service/src/models/conference.ts
@@ -1,4 +1,4 @@
-import { Model } from 'mongoose';
+import { Model} from 'mongoose';
 import { Connection } from 'mongoose';
 import { Conference, ConferenceDocument, ConferenceSchema, mongoQueryType } from '../schemas/conferences';
 import { Database } from '../interfaces/database';

--- a/Notifier-service/src/routes/conference.ts
+++ b/Notifier-service/src/routes/conference.ts
@@ -27,7 +27,7 @@ export class ConferenceRoute extends Route{
      * Routes for Conference routes 
      * base route : /conferences
      * 
-     * - /getOne returns one conference data
+     * - /getOne/:id returns one conference data
      * - /:offset/:count (offset[int], count[int]) , returns several conferences , on bad argument returns empty payload
      * - /:category/:offset/:count (category[string] , offset[int], count[int]) , returns several conferences , on bad argument returns empty payload
      * - /:categories , returns list of categories, returns null payload on fail
@@ -35,7 +35,7 @@ export class ConferenceRoute extends Route{
      * @memberof ConferenceRoute
      */
     protected setRoutes(){
-        this.router.get("/getone",this.controller.getOne)
+        this.router.get("/getone/:id",this.controller.getOne)
         this.router.get("/:offset/:count" , this.controller.getConferences)
         this.router.get("/:category/:offset/:count" , this.controller.getConferencesFomCategory)
         this.router.get("/categories" , this.controller.getCategories)

--- a/Notifier-service/src/schemas/conferences.ts
+++ b/Notifier-service/src/schemas/conferences.ts
@@ -17,10 +17,6 @@ type Conference = {
     bulkText?:string; // optional field
 }
 
-type mongoQueryType = {
-    _id?: string;
-}
-
 interface ConferenceDocument extends Document {
     title:string;
     url:string;
@@ -44,7 +40,7 @@ let ConferenceSchema = new Schema({
     deadline:{type:Date , required:true},
 } , {strict : false});
 
-export {Conference , ConferenceDocument , ConferenceSchema, mongoQueryType}
+export {Conference , ConferenceDocument , ConferenceSchema}
 
 
 

--- a/Notifier-service/src/schemas/conferences.ts
+++ b/Notifier-service/src/schemas/conferences.ts
@@ -17,6 +17,10 @@ type Conference = {
     bulkText?:string; // optional field
 }
 
+type mongoQueryType = {
+    _id?: string;
+}
+
 interface ConferenceDocument extends Document {
     title:string;
     url:string;
@@ -39,7 +43,7 @@ let ConferenceSchema = new Schema({
     deadline:{type:Date , required:true},
 } , {strict : false});
 
-export {Conference , ConferenceDocument , ConferenceSchema}
+export {Conference , ConferenceDocument , ConferenceSchema, mongoQueryType}
 
 
 

--- a/Notifier-service/src/schemas/conferences.ts
+++ b/Notifier-service/src/schemas/conferences.ts
@@ -5,6 +5,7 @@ type Conference = {
     title:string;
     url:string;
     deadline:Date;
+    _id?: string;
     metadata?:{
         [tag:string]:Metadata
     };

--- a/Notifier-service/src/schemas/conferences.ts
+++ b/Notifier-service/src/schemas/conferences.ts
@@ -38,6 +38,7 @@ interface ConferenceDocument extends Document {
 } 
 
 let ConferenceSchema = new Schema({
+    _id: {type:String, required:true},
     title:{type:String , required:true},
     url:{type:String , required:true},
     deadline:{type:Date , required:true},

--- a/Notifier-service/src/services/conference.spec.ts
+++ b/Notifier-service/src/services/conference.spec.ts
@@ -1,15 +1,23 @@
 import { ConferenceModel } from '../interfaces/models/conference'
 import { ConferenceServiceI } from './conference'
+import * as dotenv from 'dotenv'
+import { MongoDb } from '../database/mongodb'
+import { ConferenceModelMongo } from '../models/conference'
+import { ConferenceDocument } from '../schemas/conferences'
 
 describe("Testing Conferences Service Implementation " ,() => {
+    dotenv.config()
     let ModelMock = jest.fn<ConferenceModel , []>()
     let model = new ModelMock()
     let categories = ["category1" , "category2"]
     model.getCategories = jest.fn(() => Promise.resolve(["category1" , "category2"]))
     model.getConferences = jest.fn( () => Promise.resolve([]) )
+    const mongo = new MongoDb()
+    const confModelMongo = new ConferenceModelMongo(mongo)
+    let queryKey = "url"
+    let queryValue = "https://www.kdd.org/kdd2020/"
+    let service = new ConferenceServiceI(model,confModelMongo)
 
-
-    let service = new ConferenceServiceI(model)
 
     test("service instantiation" , () => {
         expect(service).toBeDefined()
@@ -22,6 +30,10 @@ describe("Testing Conferences Service Implementation " ,() => {
         expect(service.getConferences).toBeDefined()
         expect(await service.getConferences(1 , 2)).toEqual([])
         expect(service.getOne).toBeDefined()
+        let queriedObj = (await confModelMongo
+        .getOne({url: queryValue }) as ConferenceDocument).toObject()
+        expect(await service.getOne(queryKey,queryValue)).toEqual(queriedObj)
+        expect(await service.getOne(queryKey,"random-text")).toBeNull()
     })
 })
 

--- a/Notifier-service/src/services/conference.spec.ts
+++ b/Notifier-service/src/services/conference.spec.ts
@@ -5,6 +5,8 @@ import { MongoDb } from '../database/mongodb'
 import { ConferenceModelMongo } from '../models/conference'
 import { ConferenceDocument } from '../schemas/conferences'
 
+var mongoose = require('mongoose');
+
 describe("Testing Conferences Service Implementation " ,() => {
     dotenv.config()
     let ModelMock = jest.fn<ConferenceModel , []>()
@@ -17,7 +19,9 @@ describe("Testing Conferences Service Implementation " ,() => {
     let queryKey = "url"
     let queryValue = "https://www.kdd.org/kdd2020/"
     let service = new ConferenceServiceI(model,confModelMongo)
-
+    //let id= '8bd11a96-ac06-58f5-8727-2ab7f12899c2'
+    //let id = '8bd11a96ac0658f587272ab7'
+    let id = '8bd11a96ac0658f587272ab7f12899c2'
 
     test("service instantiation" , () => {
         expect(service).toBeDefined()
@@ -30,10 +34,12 @@ describe("Testing Conferences Service Implementation " ,() => {
         expect(service.getConferences).toBeDefined()
         expect(await service.getConferences(1 , 2)).toEqual([])
         expect(service.getOne).toBeDefined()
+        //console.log(mongoose.Types.ObjectId(id))
         let queriedObj = (await confModelMongo
-        .getOne({url: queryValue }) as ConferenceDocument).toObject()
-        expect(await service.getOne(queryKey,queryValue)).toEqual(queriedObj)
-        expect(await service.getOne(queryKey,"random-text")).toBeNull()
+        .getOne({_id: id }) as ConferenceDocument).toObject()
+        console.log(queriedObj)
+        // expect(await service.getOne(id)).toEqual(queriedObj)
+        // expect(await service.getOne("random-text")).toBeNull()
     })
 })
 

--- a/Notifier-service/src/services/conference.spec.ts
+++ b/Notifier-service/src/services/conference.spec.ts
@@ -1,27 +1,21 @@
 import { ConferenceModel } from '../interfaces/models/conference'
 import { ConferenceServiceI } from './conference'
-import * as dotenv from 'dotenv'
-import { MongoDb } from '../database/mongodb'
-import { ConferenceModelMongo } from '../models/conference'
-import { ConferenceDocument } from '../schemas/conferences'
-
-var mongoose = require('mongoose');
 
 describe("Testing Conferences Service Implementation " ,() => {
-    dotenv.config()
     let ModelMock = jest.fn<ConferenceModel , []>()
     let model = new ModelMock()
+    let conferenceModelMongoMock = jest.fn()
+    let confModelMongo = new conferenceModelMongoMock()
     let categories = ["category1" , "category2"]
+    let mongoData: any = {title: "t",
+                    url: "u",
+                    deadline: new Date()}
+    let mongoRes: any = {toObject: jest.fn(()=>mongoData) }
+    confModelMongo.getOne = jest.fn(()=> Promise.resolve(mongoRes))
     model.getCategories = jest.fn(() => Promise.resolve(["category1" , "category2"]))
     model.getConferences = jest.fn( () => Promise.resolve([]) )
-    const mongo = new MongoDb()
-    const confModelMongo = new ConferenceModelMongo(mongo)
-    let queryKey = "url"
-    let queryValue = "https://www.kdd.org/kdd2020/"
     let service = new ConferenceServiceI(model,confModelMongo)
-    //let id= '8bd11a96-ac06-58f5-8727-2ab7f12899c2'
-    //let id = '8bd11a96ac0658f587272ab7'
-    let id = '8bd11a96ac0658f587272ab7f12899c2'
+    let id= '8bd11a96-ac06-58f5-8727-2ab7f12899c2'
 
     test("service instantiation" , () => {
         expect(service).toBeDefined()
@@ -34,12 +28,7 @@ describe("Testing Conferences Service Implementation " ,() => {
         expect(service.getConferences).toBeDefined()
         expect(await service.getConferences(1 , 2)).toEqual([])
         expect(service.getOne).toBeDefined()
-        //console.log(mongoose.Types.ObjectId(id))
-        let queriedObj = (await confModelMongo
-        .getOne({_id: id }) as ConferenceDocument).toObject()
-        console.log(queriedObj)
-        // expect(await service.getOne(id)).toEqual(queriedObj)
-        // expect(await service.getOne("random-text")).toBeNull()
+        expect(await service.getOne(id)).toEqual(mongoData)
     })
 })
 

--- a/Notifier-service/src/services/conference.ts
+++ b/Notifier-service/src/services/conference.ts
@@ -5,6 +5,8 @@ import { Logger } from '../utility/log';
 import { injectable } from 'inversify';
 import { ConferenceModelMongo } from '../models/conference';
 
+var mongoose = require('mongoose');
+
 @injectable()
 export class ConferenceServiceI extends ConferenceService {
     private logger = new Logger(this.constructor.name).getLogger()
@@ -15,7 +17,7 @@ export class ConferenceServiceI extends ConferenceService {
     async getOne(_id: string): Promise<Conference | null> {
         this.logger.debug("getOne invoked")
         let queryObj: mongoQueryType = {}
-         queryObj['_id'] = _id
+         queryObj['_id'] = mongoose.Types.ObjectId(_id)
         return new Promise<Conference | null>((resolve, reject) => {
             this.conferenceModelMongo.getOne(queryObj).then((value)=>{
                 if(value == null){

--- a/Notifier-service/src/services/conference.ts
+++ b/Notifier-service/src/services/conference.ts
@@ -1,6 +1,6 @@
 import { ConferenceService } from '../interfaces/services/conference'
 import { ConferenceModel } from '../interfaces/models/conference'
-import { Conference, mongoQueryType } from '../schemas/conferences';
+import { Conference } from '../schemas/conferences';
 import { Logger } from '../utility/log';
 import { injectable } from 'inversify';
 import { ConferenceModelMongo } from '../models/conference';
@@ -15,10 +15,8 @@ export class ConferenceServiceI extends ConferenceService {
     }
     async getOne(_id: string): Promise<Conference | null> {
         this.logger.debug("getOne invoked")
-        let queryObj: mongoQueryType = {}
-        queryObj['_id'] = _id
         return new Promise<Conference | null>((resolve, reject) => {
-            this.conferenceModelMongo.getOne(queryObj).then((value)=>{
+            this.conferenceModelMongo.getOne(_id).then((value)=>{
                 if(value == null){
                     resolve(null)
                 }else{

--- a/Notifier-service/src/services/conference.ts
+++ b/Notifier-service/src/services/conference.ts
@@ -3,30 +3,46 @@ import { ConferenceModel } from '../interfaces/models/conference'
 import { Conference } from '../schemas/conferences';
 import { Logger } from '../utility/log';
 import { injectable } from 'inversify';
+import { ConferenceModelMongo } from '../models/conference';
 
 @injectable()
 export class ConferenceServiceI extends ConferenceService {
     private logger = new Logger(this.constructor.name).getLogger()
-    constructor(private conferenceModel: ConferenceModel) {
+    constructor(private conferenceModel: ConferenceModel,
+                private conferenceModelMongo:ConferenceModelMongo) {
         super()
     }
-    async getOne(): Promise<Conference | null> {
+    async getOne(queryKey: string, queryValue: string): Promise<Conference | null> {
         this.logger.debug("getOne invoked")
         return new Promise<Conference | null>((resolve, reject) => {
-            this.conferenceModel.getOne().then(value => {
-                if (value == null) {
+            this.conferenceModelMongo.getOne({queryKey: queryValue}).then((value)=>{
+                if(value == null){
                     resolve(null)
-                }
-                else {
-                    let result = value.toObject()
-                    let conference: Conference = result
+                }else{
+                    //let result = value.toObject()
+                    let conference: Conference = value.toObject()
                     resolve(conference)
                 }
-            }).catch(err => {
-                this.logger.error("getOne retrieval failed: " + err)
-                reject(err)
+            },(error)=>{
+                this.logger.error("getOne retrieval failed: " + error)
+                reject(error)
             })
         })
+        // return new Promise<Conference | null>((resolve, reject) => {
+        //     this.conferenceModel.getOne().then(value => {
+        //         if (value == null) {
+        //             resolve(null)
+        //         }
+        //         else {
+        //             let result = value.toObject()
+        //             let conference: Conference = result
+        //             resolve(conference)
+        //         }
+        //     }).catch(err => {
+        //         this.logger.error("getOne retrieval failed: " + err)
+        //         reject(err)
+        //     })
+        // })
     }
 
 

--- a/Notifier-service/src/services/conference.ts
+++ b/Notifier-service/src/services/conference.ts
@@ -1,6 +1,6 @@
 import { ConferenceService } from '../interfaces/services/conference'
 import { ConferenceModel } from '../interfaces/models/conference'
-import { Conference } from '../schemas/conferences';
+import { Conference, mongoQueryType } from '../schemas/conferences';
 import { Logger } from '../utility/log';
 import { injectable } from 'inversify';
 import { ConferenceModelMongo } from '../models/conference';
@@ -12,10 +12,10 @@ export class ConferenceServiceI extends ConferenceService {
                 private conferenceModelMongo:ConferenceModelMongo) {
         super()
     }
-    async getOne(queryKey: string, queryValue: string): Promise<Conference | null> {
+    async getOne(_id: string): Promise<Conference | null> {
         this.logger.debug("getOne invoked")
-        let queryObj: {[key: string]: any} = {}
-        queryObj[queryKey] = queryValue
+        let queryObj: mongoQueryType = {}
+         queryObj['_id'] = _id
         return new Promise<Conference | null>((resolve, reject) => {
             this.conferenceModelMongo.getOne(queryObj).then((value)=>{
                 if(value == null){

--- a/Notifier-service/src/services/conference.ts
+++ b/Notifier-service/src/services/conference.ts
@@ -5,7 +5,6 @@ import { Logger } from '../utility/log';
 import { injectable } from 'inversify';
 import { ConferenceModelMongo } from '../models/conference';
 
-var mongoose = require('mongoose');
 
 @injectable()
 export class ConferenceServiceI extends ConferenceService {
@@ -17,7 +16,7 @@ export class ConferenceServiceI extends ConferenceService {
     async getOne(_id: string): Promise<Conference | null> {
         this.logger.debug("getOne invoked")
         let queryObj: mongoQueryType = {}
-         queryObj['_id'] = mongoose.Types.ObjectId(_id)
+        queryObj['_id'] = _id
         return new Promise<Conference | null>((resolve, reject) => {
             this.conferenceModelMongo.getOne(queryObj).then((value)=>{
                 if(value == null){

--- a/Notifier-service/src/services/conference.ts
+++ b/Notifier-service/src/services/conference.ts
@@ -14,12 +14,13 @@ export class ConferenceServiceI extends ConferenceService {
     }
     async getOne(queryKey: string, queryValue: string): Promise<Conference | null> {
         this.logger.debug("getOne invoked")
+        let queryObj: {[key: string]: any} = {}
+        queryObj[queryKey] = queryValue
         return new Promise<Conference | null>((resolve, reject) => {
-            this.conferenceModelMongo.getOne({queryKey: queryValue}).then((value)=>{
+            this.conferenceModelMongo.getOne(queryObj).then((value)=>{
                 if(value == null){
                     resolve(null)
                 }else{
-                    //let result = value.toObject()
                     let conference: Conference = value.toObject()
                     resolve(conference)
                 }
@@ -28,21 +29,7 @@ export class ConferenceServiceI extends ConferenceService {
                 reject(error)
             })
         })
-        // return new Promise<Conference | null>((resolve, reject) => {
-        //     this.conferenceModel.getOne().then(value => {
-        //         if (value == null) {
-        //             resolve(null)
-        //         }
-        //         else {
-        //             let result = value.toObject()
-        //             let conference: Conference = result
-        //             resolve(conference)
-        //         }
-        //     }).catch(err => {
-        //         this.logger.error("getOne retrieval failed: " + err)
-        //         reject(err)
-        //     })
-        // })
+
     }
 
 


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #88 

## Proposed changes

This PR changes the getOne function in Conference-Notify\Notifier-service\src\services\conference.ts to retrieve conference information by using an id passed to it and querying the same from Mongo.
The prototypes for some functions have been changed. For now I am using URL as the unique id.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [x ] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Results of npm test
![image](https://user-images.githubusercontent.com/37807893/79419312-3956b700-7fd4-11ea-8b98-d20a5988d7ab.png)


## Other information

Any other information that is important to this pull request
