### PR TITLE
Fixed broken links in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ It will run all the unit tests written and kept under test folder
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](https://github.com/rajatkb/Conference-Notify/blob/master/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [CONTRIBUTING.md](https://github.com/rajatkb/Conference-Notify/blob/master/.github/CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
 
 ## Authors
 
@@ -231,7 +231,7 @@ Waiting for some 🧐
 
 ## License
 
-This project is licensed under the GPL License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the GPL License - see the [LICENSE.md](https://github.com/rajatkb/Conference-Notify/blob/master/LICENSE) file for details
 
 ## Acknowledgement
 


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #94 

## Proposed changes

Fixed the link to contributing.md and license in readme.md

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

# Earlier Behavior
![Screenshot_20200428-183438_1](https://user-images.githubusercontent.com/54680709/80491176-fc99a100-897f-11ea-82f4-9dc37809aa32.jpg)

# Now 
![Screenshot_20200428-183608_1](https://user-images.githubusercontent.com/54680709/80491205-07eccc80-8980-11ea-8a22-daeb7afd6cb8.jpg)
![Screenshot_20200428-183712_1](https://user-images.githubusercontent.com/54680709/80491222-0cb18080-8980-11ea-983a-b2cee83642db.jpg)

